### PR TITLE
using `mv` instead `fs.rename` to prevent cross-fs issues

### DIFF
--- a/lib/LocalFS.js
+++ b/lib/LocalFS.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fs = require('fs')
+const mv = require('mv')
 const path = require('path')
 const mkdirp = require('mkdirp')
 const async = require('async')
@@ -32,7 +33,7 @@ class LocalFsStorageProvider {
       mkdirp(this._options.directory, callback)
     }, (callback) => {
       // copy the file into the directory
-      fs.rename(attachment.path, target, callback)
+      mv(attachment.path, target, callback)
     }], (error) => {
       callback(error, target)
     })

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "async": "^1.5.2",
+    "mv": "^2.1.1",
     "check-types": "^7.0.0",
     "mkdirp": "^0.5"
   },


### PR DESCRIPTION
https://github.com/achingbrain/mongoose-crate-localfs/issues/2

The tests are still passing. There is no way to check the original issue as it is not possible to move a file cross-file-system in the tests.
